### PR TITLE
Use env vars for ACR auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ This button will launch the "Custom Deployment from a Template" experience in th
 
 In case you already have an Azure Machine Learning workspace, you can setup the necessary datasets and upload the notebooks into your existing workspace.
 
+### Environment variables
+
+The `docker/run.py` script expects the following environment variables to be set before execution:
+
+- `ACR_USERNAME` – Azure Container Registry username
+- `ACR_PASSWORD` – Azure Container Registry password
 
 ## Modules
 

--- a/docker/run.py
+++ b/docker/run.py
@@ -48,8 +48,8 @@ from azureml.core.runconfig import AzureContainerRegistry, DockerEnvironment, En
 
 registry = AzureContainerRegistry()
 registry.address = 'contosomanufac5523805767.azurecr.io'
-registry.username = 'contosomanufac5523805767'
-registry.password = 'RC+cx6OiEhgK8MY1rSGkkaj8eYnGncNC'
+registry.username = os.environ.get('ACR_USERNAME')
+registry.password = os.environ.get('ACR_PASSWORD')
 
 docker_config = DockerEnvironment()
 docker_config.enabled = True


### PR DESCRIPTION
## Summary
- use environment variables for ACR username and password
- add docs for the required variables

## Testing
- `python -m py_compile docker/run.py`

------
https://chatgpt.com/codex/tasks/task_e_685c07b247248324b7bcf445b08eacc6